### PR TITLE
fix content pagination.

### DIFF
--- a/i18n-conductor.php
+++ b/i18n-conductor.php
@@ -80,7 +80,12 @@ class I18n_Conductor
   {
     if (is_admin() || !$this->acf_exists) return $raw;
 
-    $content = get_i18n_field('content');
+    global $post;
+
+    $post->content = get_i18n_field('content');
+    
+    setup_postdata( $post );
+
     return !$content ? $raw : $content;
   }
 


### PR DESCRIPTION
@yasuyonikai 
i18n conductorでthe_content()を実行した際に、記事内ページネーションが効かない問題を解決しました。
フィルターとかで処理しているのではなく、setup_postdata()の際に処理していたので、content_filter()内で一度setup_postdata()を噛ませています。

3月中に処理出来れば大丈夫なので、どこかで検証お願いしますー。
（タスク俺に回してくれたら、自分で検証します）